### PR TITLE
bug(): enforced whitelist for base_url to prevent SSRF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR root
 COPY pyproject.toml .
 RUN pip install poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install
+RUN poetry install --no-root
 
 WORKDIR src
 COPY src/ .

--- a/dot_env_example
+++ b/dot_env_example
@@ -3,3 +3,6 @@
 CONTAINER_NAME=dataverse-importer
 PORT=8090
 APPLICATION_DIR=src
+
+# Comma-separated list of allowed Dataverse base URLs (SSRF protection)
+ALLOWED_BASE_URLS=https://portal.odissei.nl,https://portal.staging.odissei.nl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dataverse-importer"
-version = "0.1.1"
+version = "0.1.2"
 description = "A project allowing one to set up a FastAPI based Microservice, using cookiecutter"
 authors = ["Fjodor van Rijsselberg"]
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,7 @@
 import json
+import os
 import requests
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException
 from schema.input import ImporterInput
@@ -29,7 +31,7 @@ tags_metadata = [
 app = FastAPI(
     title="dataverse-importer",
     description=description,
-    version="0.1.1",
+    version="0.1.2",
     license_info={
         "name": "Apache 2.0",
         "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
@@ -46,11 +48,27 @@ async def info():
 
 @app.post("/importer", tags=["importer"])
 def import_metadata(importer_input: ImporterInput):
+    # Validate base_url against whitelist to prevent SSRF
+    allowed_urls_env = os.getenv("ALLOWED_BASE_URLS", "")
+    if not allowed_urls_env:
+        raise HTTPException(status_code=500, detail="ALLOWED_BASE_URLS not configured")
+    allowed_urls = [url.strip() for url in allowed_urls_env.split(",") if url.strip()]
+
+    base_url = importer_input.dataverse_information.base_url
+    parsed = urlparse(base_url)
+    normalized_base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+    if normalized_base_url not in allowed_urls:
+        raise HTTPException(
+            status_code=400,
+            detail=f"base_url not allowed."
+        )
+
     headers = {
         "X-Dataverse-key": importer_input.dataverse_information.api_token,
         "Content-type": "application/json"
     }
-    create_url = f"{importer_input.dataverse_information.base_url}" \
+    create_url = f"{base_url}" \
                  f"/api/dataverses/" \
                  f"{importer_input.dataverse_information.dt_alias}" \
                  f"/datasets/:import?pid={importer_input.doi}&release=no"


### PR DESCRIPTION
Fixes [SSRF vulnerability (CWE-918)](https://dans.freshdesk.com/a/tickets/34281) in the /importer endpoint. The `base_url` parameter previously accepted arbitrary URLs, allowing attackers to make the server connect to internal networks or cloud metadata services.

The fix validates `base_url` against a whitelist defined in the `ALLOWED_BASE_URLS` environment variable. Requests with URLs not in the whitelist return HTTP 400.

**Changes:**
- Added `os` and `urlparse` imports to `src/main.py`
- Added whitelist validation before making HTTP requests
- Added `ALLOWED_BASE_URLS` example to `dot_env_example`
- Fixed `poetry install --no-root` in Dockerfile
- Bumped version to 0.1.2

# Configuration

Set the environment variable with comma-separated allowed URLs:
```
ALLOWED_BASE_URLS=https://portal.odissei.nl,https://portal.staging.odissei.nl
```
If `ALLOWED_BASE_URLS` is not set, the endpoint returns HTTP 500.

# Deployment

After merge, create and push a tag for version 0.1.2 to trigger the CI/CD pipeline:
```
git tag 0.1.2
git push origin 0.1.2
```
# Note
Not directly relevant to this PR, but the [ingestion-workflow-orchestrator](https://github.com/odissei-data/ingestion-workflow-orchestrator/commit/6e28304318a1d7286de765e1510e5b5f4e06e2c8). It may be worth researching whether this service is still used elsewhere or can be decommissioned.

 # Test plan

 - Verify requests with unlisted `base_url` return 400
 - Verify requests with allowed `base_url` pass 
 - Verify missing `ALLOWED_BASE_URLS` returns 500